### PR TITLE
Rivettp/issue 64 Extend for Parent Reference Data

### DIFF
--- a/ontology/Base.ttl
+++ b/ontology/Base.ttl
@@ -22,6 +22,59 @@
 	owl:imports <http://www.omg.org/spec/LCC/Countries/CountryRepresentation/> ;
 	.
 
+gleif-base:Entity
+	a owl:Class ;
+	rdfs:subClassOf
+		[
+			a owl:Restriction ;
+			owl:onProperty gleif-base:hasNameLegalLocal ;
+			owl:cardinality "1"^^xsd:nonNegativeInteger ;
+		] ,
+		[
+			a owl:Restriction ;
+			owl:onProperty gleif-base:hasEntityExpirationReason ;
+			owl:onClass gleif-base:EntityExpirationReason ;
+			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+		] ,
+		[
+			a owl:Restriction ;
+			owl:onProperty gleif-base:hasEntityExpirationDate ;
+			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+			owl:onDataRange xsd:dateTime ;
+		] ,
+		[
+			a owl:Restriction ;
+			owl:onProperty gleif-base:hasLegalJurisdiction ;
+			owl:onClass lcc-cr:GeographicRegion ;
+			owl:minQualifiedCardinality "0"^^xsd:nonNegativeInteger ;
+		] ,
+		[
+			a owl:Restriction ;
+			owl:onProperty gleif-base:hasSuccessor ;
+			owl:onClass gleif-base:Entity ;
+			owl:minQualifiedCardinality "0"^^xsd:nonNegativeInteger ;
+		] ,
+		[
+			a owl:Restriction ;
+			owl:onProperty gleif-base:hasEntityStatus ;
+			owl:onClass gleif-base:EntityStatus ;
+			owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+		]
+		;
+	rdfs:label "entity" ;
+	rdfs:isDefinedBy <https://www.gleif.org/ontology/Base/> ;
+	skos:definition "a partnership, corporation, or other organization having the capacity to negotiate contracts, assume financial obligations, and pay off debts, organized under the laws of some jurisdiction" ;
+	skos:example """Examples of eligible legal entities include, without limitation:
+-   all financial intermediaries;
+-   banks and finance companies;
+-   all entities that issue equity, debt or other securities for other capital structures;
+-   all entities listed on an exchange;
+-   all entities that trade stock or debt, investment vehicles, including mutual funds, pension funds and alternative investment vehicles constituted as corporate entities or collective investment agreements (including umbrella funds as well as funds under an umbrella structure, hedge funds, private equity funds, etc.);
+-   all entities under the purview of a financial regulator and their affiliates, subsidiaries and holding companies;
+-   counterparties to financial transactions.""" ;
+	skos:scopeNote "The term 'legal entities' includes, but is not limited to, unique parties that are legally or financially responsible for the performance of financial transactions or have the legal right in their jurisdiction to enter independently into legal contracts, regardless of whether they are incorporated or constituted in some other way (e.g. trust, partnership, contractual). It excludes natural persons, but includes governmental organizations and supranationals." ;
+	.
+
 gleif-base:EntityExpirationReason
 	a owl:Class ;
 	rdfs:label "entity expiration reason" ;
@@ -31,7 +84,7 @@ gleif-base:EntityExpirationReason
 		gleif-base:EntityExpirationReasonDissolved
 		gleif-base:EntityExpirationReasonOther
 	) ;
-	skos:definition "The reason that a legal entity ceased to exist and/or operate." ;
+	skos:definition "The reason that an entity ceased to exist and/or operate." ;
 	.
 
 gleif-base:EntityExpirationReasonCorporateAction
@@ -76,7 +129,7 @@ gleif-base:EntityStatusActive
 		;
 	rdfs:label "active" ;
 	rdfs:isDefinedBy <https://www.gleif.org/ontology/Base/> ;
-	skos:definition "As of the last report or update, the legal entity reported that it was legally registered and operating." ;
+	skos:definition "As of the last report or update, the entity reported that it was legally registered and operating." ;
 	gleif-base:hasTag "ACTIVE" ;
 	.
 
@@ -118,72 +171,19 @@ gleif-base:Identifier
 	skos:definition "Sequence of characters, capable of uniquely identifying that with which it is associated, within a specified context." ;
 	.
 
-gleif-base:LegalEntity
-	a owl:Class ;
-	rdfs:subClassOf
-		[
-			a owl:Restriction ;
-			owl:onProperty gleif-base:hasNameLegalLocal ;
-			owl:cardinality "1"^^xsd:nonNegativeInteger ;
-		] ,
-		[
-			a owl:Restriction ;
-			owl:onProperty gleif-base:hasEntityExpirationReason ;
-			owl:onClass gleif-base:EntityExpirationReason ;
-			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
-		] ,
-		[
-			a owl:Restriction ;
-			owl:onProperty gleif-base:hasEntityExpirationDate ;
-			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
-			owl:onDataRange xsd:dateTime ;
-		] ,
-		[
-			a owl:Restriction ;
-			owl:onProperty gleif-base:hasLegalJurisdiction ;
-			owl:onClass lcc-cr:GeographicRegion ;
-			owl:minQualifiedCardinality "0"^^xsd:nonNegativeInteger ;
-		] ,
-		[
-			a owl:Restriction ;
-			owl:onProperty gleif-base:hasSuccessor ;
-			owl:onClass gleif-base:LegalEntity ;
-			owl:minQualifiedCardinality "0"^^xsd:nonNegativeInteger ;
-		] ,
-		[
-			a owl:Restriction ;
-			owl:onProperty gleif-base:hasEntityStatus ;
-			owl:onClass gleif-base:LegalEntityStatus ;
-			owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
-		]
-		;
-	rdfs:label "legal entity" ;
-	rdfs:isDefinedBy <https://www.gleif.org/ontology/Base/> ;
-	skos:definition "a partnership, corporation, or other organization having the capacity to negotiate contracts, assume financial obligations, and pay off debts, organized under the laws of some jurisdiction" ;
-	skos:example """Examples of eligible legal entities include, without limitation:
--   all financial intermediaries;
--   banks and finance companies;
--   all entities that issue equity, debt or other securities for other capital structures;
--   all entities listed on an exchange;
--   all entities that trade stock or debt, investment vehicles, including mutual funds, pension funds and alternative investment vehicles constituted as corporate entities or collective investment agreements (including umbrella funds as well as funds under an umbrella structure, hedge funds, private equity funds, etc.);
--   all entities under the purview of a financial regulator and their affiliates, subsidiaries and holding companies;
--   counterparties to financial transactions.""" ;
-	skos:scopeNote "The term 'legal entities' includes, but is not limited to, unique parties that are legally or financially responsible for the performance of financial transactions or have the legal right in their jurisdiction to enter independently into legal contracts, regardless of whether they are incorporated or constituted in some other way (e.g. trust, partnership, contractual). It excludes natural persons, but includes governmental organizations and supranationals." ;
-	.
-
 gleif-base:LegalEntityRelationship
 	a owl:Class ;
 	rdfs:subClassOf
 		[
 			a owl:Restriction ;
 			owl:onProperty gleif-base:hasChild ;
-			owl:onClass gleif-base:LegalEntity ;
+			owl:onClass gleif-base:Entity ;
 			owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
 			owl:onProperty gleif-base:hasParent ;
-			owl:onClass gleif-base:LegalEntity ;
+			owl:onClass gleif-base:Entity ;
 			owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 		]
 		;
@@ -282,7 +282,7 @@ gleif-base:PhysicalAddress
 
 gleif-base:RegistrationAuthority
 	a owl:Class ;
-	rdfs:subClassOf gleif-base:LegalEntity ;
+	rdfs:subClassOf gleif-base:Entity ;
 	rdfs:label "registration authority" ;
 	rdfs:isDefinedBy <https://www.gleif.org/ontology/Base/> ;
 	skos:altLabel "RA" ;
@@ -302,7 +302,7 @@ gleif-base:Registry
 		[
 			a owl:Restriction ;
 			owl:onProperty gleif-base:isManagedBy ;
-			owl:onClass gleif-base:LegalEntity ;
+			owl:onClass gleif-base:Entity ;
 			owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
@@ -455,8 +455,8 @@ gleif-base:hasChild
 	rdfs:label "has child" ;
 	rdfs:domain gleif-base:LegalEntityRelationship ;
 	rdfs:isDefinedBy <https://www.gleif.org/ontology/Base/> ;
-	rdfs:range gleif-base:LegalEntity ;
-	skos:definition "the legal entity that plays the child role" ;
+	rdfs:range gleif-base:Entity ;
+	skos:definition "the entity that plays the child role" ;
 	.
 
 gleif-base:hasCity
@@ -496,25 +496,25 @@ gleif-base:hasEnd
 gleif-base:hasEntityExpirationDate
 	a owl:DatatypeProperty ;
 	rdfs:label "has entity expiration date" ;
-	rdfs:domain gleif-base:LegalEntity ;
+	rdfs:domain gleif-base:Entity ;
 	rdfs:isDefinedBy <https://www.gleif.org/ontology/Base/> ;
 	rdfs:range xsd:dateTime ;
-	skos:definition "The date that the legal entity ceased to operate, whether due to dissolution, merger or acquisition" ;
+	skos:definition "The date that the entity ceased to operate, whether due to dissolution, merger or acquisition" ;
 	.
 
 gleif-base:hasEntityExpirationReason
 	a owl:ObjectProperty ;
 	rdfs:label "has entity expiration reason" ;
-	rdfs:domain gleif-base:LegalEntity ;
+	rdfs:domain gleif-base:Entity ;
 	rdfs:isDefinedBy <https://www.gleif.org/ontology/Base/> ;
 	rdfs:range gleif-base:EntityExpirationReason ;
-	skos:definition "the reason that a legal entity ceased to exist and/or operate" ;
+	skos:definition "the reason that an entity ceased to exist and/or operate" ;
 	.
 
 gleif-base:hasEntityStatus
 	a owl:ObjectProperty ;
 	rdfs:label "has entity status" ;
-	rdfs:domain gleif-base:LegalEntity ;
+	rdfs:domain gleif-base:Entity ;
 	rdfs:isDefinedBy <https://www.gleif.org/ontology/Base/> ;
 	rdfs:range gleif-base:EntityStatus ;
 	skos:definition "indicates the status of the entity (i.e., active, inactive)" ;
@@ -549,7 +549,7 @@ gleif-base:hasLastUpdateDate
 gleif-base:hasLegalJurisdiction
 	a owl:ObjectProperty ;
 	rdfs:label "has legal jurisdiction" ;
-	rdfs:domain gleif-base:LegalEntity ;
+	rdfs:domain gleif-base:Entity ;
 	rdfs:isDefinedBy <https://www.gleif.org/ontology/Base/> ;
 	rdfs:range lcc-cr:GeographicRegion ;
 	skos:altLabel "is organized in" ;
@@ -669,8 +669,8 @@ gleif-base:hasParent
 	rdfs:label "has parent" ;
 	rdfs:domain gleif-base:LegalEntityRelationship ;
 	rdfs:isDefinedBy <https://www.gleif.org/ontology/Base/> ;
-	rdfs:range gleif-base:LegalEntity ;
-	skos:definition "the legal entity that plays the parent role" ;
+	rdfs:range gleif-base:Entity ;
+	skos:definition "the entity that plays the parent role" ;
 	.
 
 gleif-base:hasPostalCode
@@ -710,10 +710,10 @@ gleif-base:hasStart
 gleif-base:hasSuccessor
 	a owl:ObjectProperty ;
 	rdfs:label "has successor" ;
-	rdfs:domain gleif-base:LegalEntity ;
+	rdfs:domain gleif-base:Entity ;
 	rdfs:isDefinedBy <https://www.gleif.org/ontology/Base/> ;
-	rdfs:range gleif-base:LegalEntity ;
-	skos:definition "The surviving/new legal entity which continues/replaces this registration." ;
+	rdfs:range gleif-base:Entity ;
+	skos:definition "The surviving/new entity which continues/replaces this registration." ;
 	.
 
 gleif-base:hasTag

--- a/ontology/L1.ttl
+++ b/ontology/L1.ttl
@@ -29,9 +29,33 @@
 		;
 	.
 
-gleif-base:LegalEntity
+gleif-L1:Branch
+	a owl:Class ;
+	rdfs:subClassOf gleif-L1:LegalEntity ;
+	rdfs:label "branch" ;
+	rdfs:isDefinedBy <https://www.gleif.org/ontology/L1/> ;
+	skos:definition "The legal entity is a branch of another legal entity" ;
+	.
+
+gleif-L1:Fund
 	a owl:Class ;
 	rdfs:subClassOf
+		gleif-L1:LegalEntity ,
+		[
+			a owl:Restriction ;
+			owl:onProperty gleif-base:isManagedBy ;
+			owl:someValuesFrom gleif-L1:LegalEntity ;
+		]
+		;
+	rdfs:label "fund" ;
+	rdfs:isDefinedBy <https://www.gleif.org/ontology/L1/> ;
+	skos:definition "The legal entity is a fund managed by another legal entity." ;
+	.
+
+gleif-L1:LegalEntity
+	a owl:Class ;
+	rdfs:subClassOf
+		gleif-base:Entity ,
 		[
 			a owl:Restriction ;
 			owl:onProperty gleif-base:hasEntityExpirationReason ;
@@ -41,7 +65,7 @@ gleif-base:LegalEntity
 		[
 			a owl:Restriction ;
 			owl:onProperty gleif-base:hasSuccessor ;
-			owl:onClass gleif-base:LegalEntity ;
+			owl:onClass gleif-L1:LegalEntity ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
@@ -136,29 +160,7 @@ gleif-base:LegalEntity
 			) ;
 		]
 		;
-	.
-
-gleif-L1:Branch
-	a owl:Class ;
-	rdfs:subClassOf gleif-base:LegalEntity ;
-	rdfs:label "branch" ;
 	rdfs:isDefinedBy <https://www.gleif.org/ontology/L1/> ;
-	skos:definition "The legal entity is a branch of another legal entity" ;
-	.
-
-gleif-L1:Fund
-	a owl:Class ;
-	rdfs:subClassOf
-		gleif-base:LegalEntity ,
-		[
-			a owl:Restriction ;
-			owl:onProperty gleif-base:isManagedBy ;
-			owl:someValuesFrom gleif-base:LegalEntity ;
-		]
-		;
-	rdfs:label "fund" ;
-	rdfs:isDefinedBy <https://www.gleif.org/ontology/L1/> ;
-	skos:definition "The legal entity is a fund managed by another legal entity." ;
 	.
 
 gleif-L1:LegalEntityIdentifier
@@ -168,7 +170,7 @@ gleif-L1:LegalEntityIdentifier
 		[
 			a owl:Restriction ;
 			owl:onProperty gleif-base:identifies ;
-			owl:onClass gleif-base:LegalEntity ;
+			owl:onClass gleif-L1:LegalEntity ;
 			owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 		]
 		;
@@ -208,7 +210,7 @@ gleif-L1:LegalEntityIdentifierRegistryEntry
 		[
 			a owl:Restriction ;
 			owl:onProperty gleif-base:records ;
-			owl:onClass gleif-base:LegalEntity ;
+			owl:onClass gleif-L1:LegalEntity ;
 			owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
@@ -249,7 +251,7 @@ gleif-L1:LegalEntityIdentifierRegistryEntry
 
 gleif-L1:LocalOperatingUnit
 	a owl:Class ;
-	rdfs:subClassOf gleif-base:LegalEntity ;
+	rdfs:subClassOf gleif-L1:LegalEntity ;
 	rdfs:label "local operating unit" ;
 	rdfs:isDefinedBy <https://www.gleif.org/ontology/L1/> ;
 	skos:altLabel "LOU" ;
@@ -432,7 +434,7 @@ gleif-L1:RegistrationStatusTransferred
 
 gleif-L1:SoleProprietor
 	a owl:Class ;
-	rdfs:subClassOf gleif-base:LegalEntity ;
+	rdfs:subClassOf gleif-L1:LegalEntity ;
 	rdfs:label "sole proprietor" ;
 	rdfs:isDefinedBy <https://www.gleif.org/ontology/L1/> ;
 	skos:definition "The legal entity represents an individual acting in a business capacity" ;
@@ -515,7 +517,7 @@ gleif-L1:hasLegalAddress
 gleif-L1:hasLegalForm
 	a owl:ObjectProperty ;
 	rdfs:label "has legal form" ;
-	rdfs:domain gleif-base:LegalEntity ;
+	rdfs:domain gleif-base:Entity ;
 	rdfs:isDefinedBy <https://www.gleif.org/ontology/L1/> ;
 	rdfs:range gleif-elf:EntityLegalForm ;
 	skos:definition "The legal form of the entity, taken from the ISO Entity Legal Form (ELF) data set maintained by GLEIF." ;
@@ -524,7 +526,7 @@ gleif-L1:hasLegalForm
 gleif-L1:hasLegalFormText
 	a owl:DatatypeProperty ;
 	rdfs:label "has legal form" ;
-	rdfs:domain gleif-base:LegalEntity ;
+	rdfs:domain gleif-base:Entity ;
 	rdfs:isDefinedBy <https://www.gleif.org/ontology/L1/> ;
 	skos:definition "A legacy code or textual description for the legal entity's legal form, used until a current code from the GLEIF-maintained list can be used." ;
 	.

--- a/ontology/L2.ttl
+++ b/ontology/L2.ttl
@@ -42,14 +42,14 @@ gleif-base:LegalEntityRelationship
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty gleif-base:hasChild ;
-			owl:onClass gleif-base:LegalEntity ;
+			owl:onProperty gleif-base:hasParent ;
+			owl:onClass gleif-base:Entity ;
 			owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty gleif-base:hasParent ;
-			owl:onClass gleif-base:LegalEntity ;
+			owl:onProperty gleif-base:hasChild ;
+			owl:onClass gleif-L1:LegalEntity ;
 			owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[

--- a/ontology/L2Parent.ttl
+++ b/ontology/L2Parent.ttl
@@ -29,20 +29,20 @@
 	skos:note "If the direct and / or ultimate parents of an LEI registrant do not have an LEI, the following applies: The child legal entity will be obliged to report reference data on its direct and ultimate parents to the LEI issuing organization in accordance with the document, titled Parent Reference Data Format. " ;
 	.
 
-gleif-L2parent:LegalEntityWithoutLEI
+gleif-L2parent:EntityWithoutLEI
 	a owl:Class ;
 	rdfs:subClassOf
-		gleif-base:LegalEntity ,
+		gleif-base:Entity ,
 		[
 			a owl:Restriction ;
-			owl:onProperty gleif-base:hasEntityExpirationReason ;
-			owl:onClass gleif-base:EntityExpirationReason ;
+			owl:onProperty gleif-base:hasSuccessor ;
+			owl:onClass gleif-base:Entity ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty gleif-base:hasSuccessor ;
-			owl:onClass gleif-base:LegalEntity ;
+			owl:onProperty gleif-base:hasEntityExpirationReason ;
+			owl:onClass gleif-base:EntityExpirationReason ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
@@ -139,7 +139,7 @@ gleif-L2parent:LegalEntityWithoutLEI
 		;
 	.
 
-gleif-L2parent:ParentLegalEntityRegistryEntry
+gleif-L2parent:ParentEntityRegistryEntry
 	a owl:Class ;
 	rdfs:subClassOf
 		gleif-base:RegistryEntry ,
@@ -157,12 +157,6 @@ gleif-L2parent:ParentLegalEntityRegistryEntry
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty gleif-base:records ;
-			owl:onClass gleif-base:LegalEntity ;
-			owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
-		] ,
-		[
-			a owl:Restriction ;
 			owl:onProperty gleif-L1:hasManagingLOU ;
 			owl:onClass gleif-L1:LocalOperatingUnit ;
 			owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
@@ -171,6 +165,12 @@ gleif-L2parent:ParentLegalEntityRegistryEntry
 			a owl:Restriction ;
 			owl:onProperty gleif-base:hasRegistrationStatus ;
 			owl:onClass gleif-L1:RegistrationStatus ;
+			owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+		] ,
+		[
+			a owl:Restriction ;
+			owl:onProperty gleif-base:records ;
+			owl:onClass gleif-L2parent:EntityWithoutLEI ;
 			owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
@@ -186,7 +186,7 @@ gleif-L2parent:ParentLegalEntityRegistryEntry
 			owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 		]
 		;
-	rdfs:label "parent legal entity registry entry" ;
+	rdfs:label "parent entity registry entry" ;
 	rdfs:isDefinedBy <https://www.gleif.org/ontology/L2Parent/> ;
 	skos:definition "The Registration container element which contains all information on the legal entity's parent registration with the Managing LOU." ;
 	.
@@ -209,7 +209,7 @@ gleif-L2parent:RegistrationStatusPendingValidation
 		;
 	rdfs:label "pending validation" ;
 	rdfs:isDefinedBy <https://www.gleif.org/ontology/L2Parent//> ;
-	skos:definition "An application for an LEI that has been submitted and which is being processed and validated." ;
+	skos:definition "Entity information that has been submitted and which is being processed and validated." ;
 	gleif-base:hasTag "PENDING_VALIDATION" ;
 	.
 

--- a/ontology/L2inferences.ttl
+++ b/ontology/L2inferences.ttl
@@ -80,7 +80,7 @@ gleif-L2-infer:hasChildEntity
 gleif-L2-infer:hasChildRelationship
 	a owl:ObjectProperty ;
 	rdfs:label "has child relationship" ;
-	rdfs:domain gleif-base:LegalEntity ;
+	rdfs:domain gleif-base:Entity ;
 	rdfs:isDefinedBy <https://www.gleif.org/ontology/L2inferences/> ;
 	rdfs:range gleif-base:LegalEntityRelationship ;
 	owl:inverseOf gleif-base:hasParent ;
@@ -99,7 +99,7 @@ gleif-L2-infer:hasParentEntity
 gleif-L2-infer:hasParentRelationship
 	a owl:ObjectProperty ;
 	rdfs:label "has parent relationship" ;
-	rdfs:domain gleif-base:LegalEntity ;
+	rdfs:domain gleif-L1:LegalEntity ;
 	rdfs:isDefinedBy <https://www.gleif.org/ontology/L2inferences/> ;
 	rdfs:range gleif-base:LegalEntityRelationship ;
 	owl:inverseOf gleif-base:hasChild ;

--- a/sample/L1Data.ttl
+++ b/sample/L1Data.ttl
@@ -84,7 +84,7 @@ gleif-L1-data:213800PRXJ7WA41AIN67-LAL
 	.
 
 gleif-L1-data:213800PRXJ7WA41AIN67-LE
-	a gleif-base:LegalEntity ;
+	a gleif-L1:LegalEntity ;
 	gleif-base:hasEntityStatus gleif-base:EntityStatusActive ;
 	gleif-base:hasLegalJurisdiction lcc-3166-1-add:CTRY-MX ;
 	gleif-base:hasNameLegalLocal "MUFG BANK MEXICO SOCIEDAD ANONIMA INSTITUCION DE BANCA MULTIPLE FILIAL"@es ;
@@ -130,7 +130,7 @@ gleif-L1-data:213800YK2FEXWNMT3R12-LAL
 	.
 
 gleif-L1-data:213800YK2FEXWNMT3R12-LE
-	a gleif-base:LegalEntity ;
+	a gleif-L1:LegalEntity ;
 	gleif-base:hasEntityExpirationDate "2018-09-28T00:00:00Z"^^xsd:dateTime ;
 	gleif-base:hasEntityExpirationReason gleif-base:EntityExpirationReasonCorporateAction ;
 	gleif-base:hasEntityStatus gleif-base:EntityStatusInactive ;
@@ -186,7 +186,7 @@ gleif-L1-data:25490050856CG53NAC28-LAL
 	.
 
 gleif-L1-data:25490050856CG53NAC28-LE
-	a gleif-base:LegalEntity ;
+	a gleif-L1:LegalEntity ;
 	gleif-base:hasEntityStatus gleif-base:EntityStatusActive ;
 	gleif-base:hasLegalJurisdiction lcc-3166-2-add:REG-US-DE ;
 	gleif-base:hasNameLegalLocal "5210 Concourse, LP"@en ;
@@ -289,7 +289,7 @@ gleif-L1-data:5493007CICYM7A0SZ714-LAL
 	.
 
 gleif-L1-data:5493007CICYM7A0SZ714-LE
-	a gleif-base:LegalEntity ;
+	a gleif-L1:LegalEntity ;
 	gleif-base:hasEntityStatus gleif-base:EntityStatusActive ;
 	gleif-base:hasLegalJurisdiction lcc-3166-1-add:CTRY-MX ;
 	gleif-base:hasNameLegalLocal "KI MEXICO S DE RL DE CV"@es ;


### PR DESCRIPTION
Issue #64 Support Parent Reference Format, which involves generalizing base:Entity from L1:LegalEntity and introducing new ontology L2Parent