### PR TITLE
Issue-145 Implementation for Registration Authority

### DIFF
--- a/code/RegistrationAuthoritySkeleton.ttl
+++ b/code/RegistrationAuthoritySkeleton.ttl
@@ -1,13 +1,7 @@
-# baseURI: https://www.gleif.org/ontology/sample/RegistrationAuthorityData/
-# imports: https://www.gleif.org/ontology/Base/
-# imports: https://www.gleif.org/ontology/RegistrationAuthority/
-# imports: https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes-Adjunct/
-# imports: https://www.omg.org/spec/LCC/Countries/ISO3166-2-SubdivisionCodes-Adjunct/
-
-@base <https://www.gleif.org/ontology/sample/RegistrationAuthorityData/> .
+@base <https://www.gleif.org/ontology/RegistrationAuthorityData/> .
 @prefix dct: <http://purl.org/dc/terms/> .
 @prefix gleif-L1: <https://www.gleif.org/ontology/L1/> .
-@prefix gleif-RA-data: <https://www.gleif.org/ontology/sample/RegistrationAuthorityData/> .
+@prefix gleif-RA-data: <https://www.gleif.org/ontology/RegistrationAuthorityData/> .
 @prefix gleif-base: <https://www.gleif.org/ontology/Base/> .
 @prefix gleif-ra: <https://www.gleif.org/ontology/RegistrationAuthority/> .
 @prefix lcc-3166-1-adj: <https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes-Adjunct/> .
@@ -38,7 +32,7 @@
 		<https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes-Adjunct/> ,
 		<https://www.omg.org/spec/LCC/Countries/ISO3166-2-SubdivisionCodes-Adjunct/>
 		;
-	owl:versionIRI <https://www.gleif.org/ontology/RegistrationAuthority-v1.0/sample/RegistrationAuthorityData/> ;
+	owl:versionIRI <https://www.gleif.org/ontology/RegistrationAuthority-v1.4/RegistrationAuthorityData/> ;
 	skos:note """There are 2 categories of individual:
     1) The BusinessRegistry and RACode. The URI is the RA code.
     2) The RegistrationAuthority organization. The URI is that of the BusinessRegistry followed by -ORG.""" ;


### PR DESCRIPTION
Uses an accompanying Skeleton file.
Looks up the correct administrative language code for the country from LCC for local names.
Incorporates a few overrides where regions could not be looked up in the LCC reference data; however for Colombia and Germany the jurisdictions seem to be cities so they are retained as comments.
